### PR TITLE
Darken selection background

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -35,7 +35,7 @@ atom-text-editor, :host {
   }
 
   .selection .region {
-    background-color: @base01;
+    background-color: @base02;
     color: @base03;
   }
 


### PR DESCRIPTION
Comments and the selection background are both `@base01`.

<img width="288" alt="current" src="https://cloud.githubusercontent.com/assets/747861/12375176/63c3c838-bcb6-11e5-9f21-6fcee9c54000.png">

Changing it to `@base02` as suggested by @burabure in #2 is an improvement.

<img width="290" alt="darkened" src="https://cloud.githubusercontent.com/assets/747861/12375177/664d7964-bcb6-11e5-9d50-ac25e94aaadf.png">

Closes #2.
