### PR TITLE
Color .storage.modifier

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -62,7 +62,8 @@ atom-text-editor, :host {
   color: @magenta;
 }
 
-.storage.type {
+.storage.type,
+.storage.modifier {
   color: @green;
 }
 


### PR DESCRIPTION
Keywords like `var`, `let`, and `const` aren’t colored.

<img width="240" alt="screen shot 2016-01-17 at 01 19 32" src="https://cloud.githubusercontent.com/assets/747861/12375217/86cef92c-bcb8-11e5-8f88-9cf4bf31a815.png">

This pull request colors them.

<img width="237" alt="screen shot 2016-01-17 at 01 19 14" src="https://cloud.githubusercontent.com/assets/747861/12375223/c36d3c90-bcb8-11e5-9d25-dcaaaa8f097b.png">